### PR TITLE
Re-export Layer for convenience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "tracing-subscriber-init"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/tracing-subscriber-init"
-version = "0.1.2"
+version = "0.1.3"
 
 [package.metadata.cargo-all-features]
 denylist = ["time"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,3 +365,6 @@ pub use tracing_subscriber::fmt::time::Uptime;
 #[cfg(feature = "tstime")]
 #[doc(no_inline)]
 pub use tracing_subscriber::fmt::time::UtcTime;
+#[cfg(feature = "tstime")]
+#[doc(no_inline)]
+pub use tracing_subscriber::Layer;


### PR DESCRIPTION
* Re-export `tracing_subscriber::Layer` for convenience.