### PR TITLE
MSRV to 1.67, deps bump to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            rust: "1.65.0"
+            rust: "1.67.0"
           - os: ubuntu-latest
             rust: stable
           - os: ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            rust: "1.65.0"
+            rust: "1.67.0"
           - os: macos-latest
             rust: stable
           - os: macos-latest
@@ -116,7 +116,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            rust: "1.65.0"
+            rust: "1.67.0"
           - os: windows-latest
             rust: stable
           - os: windows-latest
@@ -153,7 +153,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            rust: "1.65.0"
+            rust: "1.67.0"
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             rust: stable
@@ -208,7 +208,7 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            rust: "1.65.0"
+            rust: "1.67.0"
             target: x86_64-apple-darwin
           - os: macos-latest
             rust: stable
@@ -256,7 +256,7 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            rust: "1.65.0"
+            rust: "1.67.0"
             target: x86_64-pc-windows-msvc
           - os: windows-latest
             rust: stable
@@ -268,7 +268,7 @@ jobs:
             rust: nightly
             target: x86_64-pc-windows-msvc
           - os: windows-latest
-            rust: "1.65.0"
+            rust: "1.67.0"
             target: x86_64-pc-windows-gnu
           - os: windows-latest
             rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ tstime = ["tracing-subscriber/time", "time"]
 unstable = []
 
 [dependencies]
-anyhow = "1.0.71"
-time = { version = "0.3.21", default-features = false, features = [
+anyhow = "1.0.72"
+time = { version = "0.3.23", default-features = false, features = [
     "formatting",
 ], optional = true }
 tracing = { version = "0.1.37", features = ["max_level_trace"] }
 tracing-subscriber = "0.3.17"
 
 [build-dependencies]
-rustversion = "1.0.12"
+rustversion = "1.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "tracing-subscriber-init"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/tracing-subscriber-init"
-version = "0.1.3"
+version = "0.1.4"
 
 [package.metadata.cargo-all-features]
 denylist = ["time"]

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Convenience trait and functions to ease [`tracing-subscriber`][tracing-subscribe
 [![CI](https://github.com/rustyhorde/tracing-subscriber-init/actions/workflows/audit.yml/badge.svg)](https://github.com/rustyhorde/tracing-subscriber-init/actions)
 
 ## MSRV
-The current minimum supported rust version is 1.65.0 for non-Windows platforms
-
-The current minimum supported rust version is 1.65.0 for Windows platforms
+The current minimum supported rust version is 1.67.0
 
 [tracing-subscriber]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/
 

--- a/build.rs
+++ b/build.rs
@@ -30,10 +30,10 @@ fn stable() {
 #[rustversion::not(stable)]
 fn stable() {}
 
-#[rustversion::before(1.66)]
+#[rustversion::before(1.67)]
 fn msrv() {}
 
-#[rustversion::since(1.66)]
+#[rustversion::since(1.67)]
 fn msrv() {
     println!("cargo:rustc-cfg=msrv");
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,7 @@ pub trait Config {
     }
     /// Configures how synthesized events are emitted at points in the span lifecycle.
     /// This defaults to [`None`](std::option::Option::None).
-    /// See [with_span_event](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Layer.html#method.with_span_events)
+    /// See [`with_span_event`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Layer.html#method.with_span_events)
     fn with_span_events(&self) -> Option<FmtSpan> {
         None
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,9 @@
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns_lint,
-        rustdoc_missing_doc_code_examples,
         strict_provenance,
+        type_privacy_lints,
+        rustdoc_missing_doc_code_examples,
     )
 )]
 #![cfg_attr(
@@ -163,6 +164,7 @@
         ellipsis_inclusive_range_patterns,
         explicit_outlives_requirements,
         exported_private_dependencies,
+        ffi_unwind_calls,
         forbidden_lint_groups,
         for_loops_over_fallibles,
         function_item_references,
@@ -181,7 +183,6 @@
         legacy_derive_helpers,
         let_underscore_drop,
         macro_use_extern_crate,
-        map_unit_fn,
         meta_variable_misuse,
         missing_abi,
         missing_copy_implementations,
@@ -265,19 +266,25 @@
         while_true,
     )
 )]
-// If nightly and unstable, allow `unstable_features`
-#![cfg_attr(all(msrv, feature = "unstable", nightly), allow(unstable_features))]
+#![cfg_attr(msrv, allow(single_use_lifetimes))]
+// If nightly or beta and unstable, allow `unstable_features`
+#![cfg_attr(
+    all(msrv, feature = "unstable", any(nightly, beta)),
+    allow(unstable_features)
+)]
 // The unstable lints
 #![cfg_attr(
     all(msrv, feature = "unstable", nightly),
     deny(
-        ffi_unwind_calls,
         fuzzy_provenance_casts,
         lossy_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,
+        private_bounds,
+        private_interfaces,
         unfulfilled_lint_expectations,
+        unnameable_types,
     )
 )]
 // If nightly and not unstable, deny `unstable_features`
@@ -286,19 +293,41 @@
 #![cfg_attr(
     all(msrv, nightly),
     deny(
-        invalid_macro_export_arguments,
-        suspicious_double_ref_op,
-        undefined_naked_function_abi,
+        ambiguous_glob_imports,
+        incorrect_fn_null_checks,
+        invalid_reference_casting,
+        unknown_diagnostic_attributes
     )
 )]
 // nightly or beta only lints
-#![cfg_attr(all(msrv, any(beta, nightly)), deny(ambiguous_glob_reexports))]
+#![cfg_attr(
+    all(msrv, any(beta, nightly)),
+    deny(
+        ambiguous_glob_reexports,
+        byte_slice_in_packed_struct_with_derive,
+        dropping_copy_types,
+        dropping_references,
+        forgetting_copy_types,
+        forgetting_references,
+        hidden_glob_reexports,
+        invalid_from_utf8,
+        invalid_macro_export_arguments,
+        invalid_nan_comparisons,
+        map_unit_fn,
+        suspicious_double_ref_op,
+        undefined_naked_function_abi,
+        unused_associated_type_bounds,
+    )
+)]
 // beta only lints
 // #![cfg_attr( all(msrv, beta), deny())]
 // beta or stable only lints
 // #![cfg_attr(all(msrv, any(beta, stable)), deny())]
 // stable only lints
-// #![cfg_attr(all(msrv, stable), deny())]
+#![cfg_attr(
+    all(msrv, stable),
+    deny(bindings_with_variant_name, implied_bounds_entailment)
+)]
 // clippy lints
 #![cfg_attr(msrv, deny(clippy::all, clippy::pedantic))]
 // #![cfg_attr(msrv, allow())]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,6 @@
         ellipsis_inclusive_range_patterns,
         explicit_outlives_requirements,
         exported_private_dependencies,
-        ffi_unwind_calls,
         forbidden_lint_groups,
         for_loops_over_fallibles,
         function_item_references,
@@ -276,6 +275,7 @@
 #![cfg_attr(
     all(msrv, feature = "unstable", nightly),
     deny(
+        ffi_unwind_calls,
         fuzzy_provenance_casts,
         lossy_provenance_casts,
         multiple_supertrait_upcastable,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@
         bare_trait_objects,
         // box_pointers,
         break_with_label_and_loop,
-        byte_slice_in_packed_struct_with_derive,
         clashing_extern_declarations,
         coherence_leak_check,
         confusable_idents,


### PR DESCRIPTION
* MSRV to `1.67` to support `time-macros`
* Deps bumped to latest